### PR TITLE
Fix docker multi stage build error in version `20.10.5`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:15 AS builder
 
 COPY . .
 
-CMD ["./gradlew", "app:assemble"]
+RUN ./gradlew app:assemble
 
 FROM openjdk:15
 


### PR DESCRIPTION
서버는 Docker버전이 `20.10.5`을 사용하고 있고, 로컬은 `19.03.8`을 사용하고 있다.
`20.10.5`에서 이미지에 CMD를 하면 빌드가 실패하는 현상이 발생했다.
따라서 CMD을 RUN으로 변경하였다.
찾아보니 CMD보다는 RUN을 사용하는게 더 일반적인 방법인 것 같다.

See Also
  - https://docs.docker.com/develop/develop-images/multistage-build/