### PR TITLE
HTTP API를 통하여 리뷰를 생성한다

### DIFF
--- a/app/src/main/java/atmosphere/web/spring/controller/MusicReviewController.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/MusicReviewController.java
@@ -1,16 +1,15 @@
 package atmosphere.web.spring.controller;
 
 import atmosphere.application.MusicReviewApplicationService;
+import atmosphere.domain.MusicReview;
 import atmosphere.web.spring.dto.MusicReviewDTO;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/music-reviews")
+@RequestMapping(path = "/music-reviews", produces = "application/json;charset=UTF-8")
 public class MusicReviewController {
     private final MusicReviewApplicationService service;
 
@@ -18,11 +17,17 @@ public class MusicReviewController {
         this.service = service;
     }
 
-    @GetMapping(produces = "application/json;charset=UTF-8")
+    @GetMapping
     List<MusicReviewDTO> getAllReviews(){
         return service.findAllMusicReviews()
             .stream()
             .map(MusicReviewDTO::fromModel)
             .collect(Collectors.toList());
+    }
+
+    @PostMapping
+    MusicReviewDTO createReview(@RequestBody MusicReviewDTO data){
+        MusicReview createdReview = service.createMusicReview(data.musicLink, data.title, data.description);
+        return MusicReviewDTO.fromModel(createdReview);
     }
 }


### PR DESCRIPTION
기존에는 음악 리뷰를 가져오는 기능밖에 제공되지 않았다.
그러나 음악을 만드는 기능도 필요하다. 그래야 사용자들이 더 많은 음악 리뷰를 작성하기 때문이다.
따라서 음악을 생성할 수 있는 HTTP API를 구현하였다.