### PR TITLE
Set CORS

### DIFF
--- a/app/src/main/java/atmosphere/App.java
+++ b/app/src/main/java/atmosphere/App.java
@@ -2,8 +2,10 @@ package atmosphere;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 @SpringBootApplication
+@CrossOrigin(origins = "https://atmop.dev")
 public class App {
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);


### PR DESCRIPTION
리액트 페이지는 `atmop.dev`로 서빙되고 있고, API는 `api.atmop.dev`로 서빙되고 있다.
그러나 API에 cors설정이 되어있지 않아서 리액트에서 API를 호출할 수 없다. 따라서 CORS를 설정해주었다.

See Also
  - https://developer.mozilla.org/ko/docs/Web/HTTP/CORS