### PR TITLE
Repository를 만들다

### DIFF
--- a/app/src/main/java/atmosphere/adapter/InMemoryMusicReviewRepository.java
+++ b/app/src/main/java/atmosphere/adapter/InMemoryMusicReviewRepository.java
@@ -1,0 +1,28 @@
+package atmosphere.adapter;
+
+import atmosphere.domain.MusicReview;
+import atmosphere.domain.MusicReviewRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class InMemoryMusicReviewRepository implements MusicReviewRepository {
+    private final List<MusicReview> musicReviewList = new ArrayList<>();
+
+    @Override
+    public List<MusicReview> getAll() {
+        return musicReviewList;
+    }
+
+    @Override
+    public void add(MusicReview musicReview) {
+        musicReviewList.add(musicReview);
+    }
+
+    @Override
+    public void deleteAll() {
+        musicReviewList.clear();
+    }
+}

--- a/app/src/main/java/atmosphere/application/MusicReviewApplicationService.java
+++ b/app/src/main/java/atmosphere/application/MusicReviewApplicationService.java
@@ -1,9 +1,9 @@
 package atmosphere.application;
 
 import atmosphere.domain.MusicReview;
+import atmosphere.domain.MusicReviewRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -11,8 +11,11 @@ import java.util.List;
  */
 @Service
 public class MusicReviewApplicationService {
-    private final List<MusicReview> musicReviewList = new ArrayList<>();
+    private final MusicReviewRepository repository;
 
+    public MusicReviewApplicationService(MusicReviewRepository repository) {
+        this.repository = repository;
+    }
     /**
      * 음악 리뷰를 생성합니다.
      *
@@ -23,7 +26,7 @@ public class MusicReviewApplicationService {
      */
     public MusicReview createMusicReview(String musicLink, String reviewTitle, String description) {
         MusicReview musicReview = new MusicReview(musicLink, reviewTitle, description);
-        musicReviewList.add(musicReview);
+        repository.add(musicReview);
         return musicReview;
     }
 
@@ -31,13 +34,13 @@ public class MusicReviewApplicationService {
      * @return 생성된 모든 리뮤 목록
      */
     public List<MusicReview> findAllMusicReviews() {
-        return musicReviewList;
+        return repository.getAll();
     }
 
     /**
      * 서비스를 초기화합니다.
      */
     public void initialize() {
-        musicReviewList.clear();
+        repository.deleteAll();
     }
 }

--- a/app/src/main/java/atmosphere/domain/MusicReviewRepository.java
+++ b/app/src/main/java/atmosphere/domain/MusicReviewRepository.java
@@ -1,0 +1,9 @@
+package atmosphere.domain;
+
+import java.util.List;
+
+public interface MusicReviewRepository {
+    List<MusicReview> getAll();
+    void add(MusicReview musicReview);
+    void deleteAll();
+}

--- a/app/src/test/java/atmosphere/application/MusicReviewCreateTest.java
+++ b/app/src/test/java/atmosphere/application/MusicReviewCreateTest.java
@@ -1,6 +1,8 @@
 package atmosphere.application;
 
+import atmosphere.adapter.InMemoryMusicReviewRepository;
 import atmosphere.domain.MusicReview;
+import atmosphere.domain.MusicReviewRepository;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -9,7 +11,8 @@ import org.assertj.core.api.Assertions;
 import java.util.List;
 
 public class MusicReviewCreateTest {
-    private final MusicReviewApplicationService musicReviewService = new MusicReviewApplicationService();
+    private final MusicReviewRepository repository = new InMemoryMusicReviewRepository();
+    private final MusicReviewApplicationService musicReviewService = new MusicReviewApplicationService(repository);
 
     private String musicLink;
     private String reviewTitle;

--- a/app/src/test/java/atmosphere/application/MusicReviewTourTest.java
+++ b/app/src/test/java/atmosphere/application/MusicReviewTourTest.java
@@ -1,6 +1,8 @@
 package atmosphere.application;
 
+import atmosphere.adapter.InMemoryMusicReviewRepository;
 import atmosphere.domain.MusicReview;
+import atmosphere.domain.MusicReviewRepository;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -9,7 +11,8 @@ import org.assertj.core.api.Assertions;
 import java.util.List;
 
 public class MusicReviewTourTest {
-    private final MusicReviewApplicationService musicReviewService = new MusicReviewApplicationService();
+    private final MusicReviewRepository repository = new InMemoryMusicReviewRepository();
+    private final MusicReviewApplicationService musicReviewService = new MusicReviewApplicationService(repository);
     private MusicReview musicReview;
     private List<MusicReview> allMusicReviews;
 


### PR DESCRIPTION
기존에는 Repository라는 개념 없이 Application Service에서 list로 관리하고 있었습니다.
그러나 이런 도메인 객체를 저장하고 가져오는 것을 Repository로 책임을 위임하면 Application Service에서는 Application 비즈니스 로직에만 집중할 수 있습니다.
따라서 Repository를 구현하고 의존성 주입을 통해서 Application Service가 사용하도록 하였습니다.

See Also
  - https://martinfowler.com/eaaCatalog/repository.html