### PR TITLE
Music Review에 ID 추가

### DIFF
--- a/app/src/main/java/atmosphere/adapter/InMemoryMusicReviewRepository.java
+++ b/app/src/main/java/atmosphere/adapter/InMemoryMusicReviewRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Repository
 public class InMemoryMusicReviewRepository implements MusicReviewRepository {
     private final List<MusicReview> musicReviewList = new ArrayList<>();
+    private Long lastId = 0L;
 
     @Override
     public List<MusicReview> getAll() {
@@ -24,5 +25,10 @@ public class InMemoryMusicReviewRepository implements MusicReviewRepository {
     @Override
     public void deleteAll() {
         musicReviewList.clear();
+    }
+
+    @Override
+    public Long nextId() {
+        return ++lastId;
     }
 }

--- a/app/src/main/java/atmosphere/application/MusicReviewApplicationService.java
+++ b/app/src/main/java/atmosphere/application/MusicReviewApplicationService.java
@@ -25,7 +25,8 @@ public class MusicReviewApplicationService {
      * @return 생성된 리뷰
      */
     public MusicReview createMusicReview(String musicLink, String reviewTitle, String description) {
-        MusicReview musicReview = new MusicReview(musicLink, reviewTitle, description);
+        Long id = repository.nextId();
+        MusicReview musicReview = new MusicReview(id, musicLink, reviewTitle, description);
         repository.add(musicReview);
         return musicReview;
     }

--- a/app/src/main/java/atmosphere/domain/MusicReview.java
+++ b/app/src/main/java/atmosphere/domain/MusicReview.java
@@ -1,14 +1,25 @@
 package atmosphere.domain;
 
 public class MusicReview {
+    private final Long id;
     private String title;
     private String description;
     private String musicLink;
 
-    public MusicReview(String musicLink, String reviewTitle, String description) {
+    public MusicReview(
+        Long id,
+        String musicLink,
+        String reviewTitle,
+        String description
+    ) {
+        this.id = id;
         this.title = reviewTitle;
         this.description = description;
         this.musicLink = musicLink;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getTitle() {

--- a/app/src/main/java/atmosphere/domain/MusicReviewRepository.java
+++ b/app/src/main/java/atmosphere/domain/MusicReviewRepository.java
@@ -6,4 +6,5 @@ public interface MusicReviewRepository {
     List<MusicReview> getAll();
     void add(MusicReview musicReview);
     void deleteAll();
+    Long nextId();
 }

--- a/app/src/main/java/atmosphere/web/spring/dto/MusicReviewDTO.java
+++ b/app/src/main/java/atmosphere/web/spring/dto/MusicReviewDTO.java
@@ -3,20 +3,23 @@ package atmosphere.web.spring.dto;
 import atmosphere.domain.MusicReview;
 
 public class MusicReviewDTO {
-    public MusicReviewDTO(String title, String description, String musicLink) {
+    public Long id;
+    public String title;
+    public String description;
+    public String musicLink;
+
+    public MusicReviewDTO(Long id, String title, String description, String musicLink) {
+        this.id = id;
         this.title = title;
         this.description = description;
         this.musicLink = musicLink;
     }
     static public MusicReviewDTO fromModel(MusicReview model) {
         return new MusicReviewDTO(
+            model.getId(),
             model.getTitle(),
             model.getDescription(),
             model.getMusicLink()
         );
     }
-
-    public String title;
-    public String description;
-    public String musicLink;
 }

--- a/app/src/test/java/atmosphere/web/MusicReviewTest.java
+++ b/app/src/test/java/atmosphere/web/MusicReviewTest.java
@@ -99,7 +99,7 @@ public class MusicReviewTest {
                 String musicLink = "https://www.youtube.com/watch?v=65BAeDpwzGY";
                 String reviewTitle = "Sayuri - Mikazuki";
                 String description = "사유리의 데뷔곡인 '미카즈키'이다. 란포기담 Game of Laplace의 엔딩으로 사용되었다.";
-                MusicReviewDTO data = new MusicReviewDTO(musicLink, reviewTitle, description);
+                MusicReviewDTO data = new MusicReviewDTO(1L, musicLink, reviewTitle, description);
 
                 requestBody = mapper.writeValueAsString(data);
             }


### PR DESCRIPTION
기존에는 MusicReview에 ID가 없어서 각각의 리뷰를 식별하기 힘들었습니다.
하지만 한가지 리뷰를 보는 페이지를 만들기 위하여 각각의 리뷰를 식별할 필요가 생겼습니다.
따라서 ID를 추가하고, HTTP API의 response로 내려주도록 변경하였습니다.