### PR TITLE
Implement HTTP API for get specific music review

### DIFF
--- a/app/src/main/java/atmosphere/error/NotFountMusicReview.java
+++ b/app/src/main/java/atmosphere/error/NotFountMusicReview.java
@@ -1,0 +1,7 @@
+package atmosphere.error;
+
+public class NotFountMusicReview extends RuntimeException {
+    public NotFountMusicReview(Long id) {
+        super("Not Found Music Review. ID is " + id.toString());
+    }
+}

--- a/app/src/main/java/atmosphere/web/spring/controller/MusicReviewAdvice.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/MusicReviewAdvice.java
@@ -1,0 +1,16 @@
+package atmosphere.web.spring.controller;
+
+import atmosphere.error.NotFountMusicReview;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MusicReviewAdvice {
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String errorHandler(NotFountMusicReview e) {
+        return e.getMessage();
+    }
+}

--- a/app/src/main/java/atmosphere/web/spring/controller/MusicReviewController.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/MusicReviewController.java
@@ -2,6 +2,7 @@ package atmosphere.web.spring.controller;
 
 import atmosphere.application.MusicReviewApplicationService;
 import atmosphere.domain.MusicReview;
+import atmosphere.error.NotFountMusicReview;
 import atmosphere.web.spring.dto.MusicReviewDTO;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +25,15 @@ public class MusicReviewController {
             .stream()
             .map(MusicReviewDTO::fromModel)
             .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{id}")
+    MusicReviewDTO getSpecificReview(@PathVariable Long id){
+        return service.findSpecificReview(id)
+            .map(MusicReviewDTO::fromModel)
+            .orElseThrow(
+                () -> new NotFountMusicReview(id)
+            );
     }
 
     @PostMapping

--- a/app/src/test/java/atmosphere/web/MusicReviewTest.java
+++ b/app/src/test/java/atmosphere/web/MusicReviewTest.java
@@ -1,6 +1,7 @@
 package atmosphere.web;
 
 import atmosphere.application.MusicReviewApplicationService;
+import atmosphere.domain.MusicReview;
 import atmosphere.web.spring.dto.MusicReviewDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,6 +86,52 @@ public class MusicReviewTest {
         }
     }
 
+    @Nested
+    @DisplayName("특정 리뷰를 가져올 때")
+    class Describe_getSpecificReview {
+        @Nested
+        @DisplayName("생성된 리뷰가 없다면")
+        class Context_notExistReviews {
+            @Test
+            @DisplayName("404를 반환한다.")
+            void it_shouldReturn404() throws Exception {
+                mockMvc.perform(get("/music-reviews/9999"))
+                    .andExpect(
+                        status().is(404));
+            }
+        }
+        @Nested
+        @DisplayName("리뷰가 이미 생성되어 있다면")
+        class Context_alreadyExistReview {
+            private String musicLink;
+            private String reviewTitle;
+            private String description;
+            private MusicReview createdMusicReview;
+
+            @BeforeEach
+            void createReview() {
+                musicLink = "https://www.youtube.com/watch?v=65BAeDpwzGY";
+                reviewTitle = "Sayuri - Mikazuki";
+                description = "사유리의 데뷔곡인 '미카즈키'이다. 란포기담 Game of Laplace의 엔딩으로 사용되었다.";
+                createdMusicReview = service.createMusicReview(musicLink, reviewTitle, description);
+            }
+
+            @Test
+            @DisplayName("생성된 리뷰를 반환한다.")
+            void it_shouldReturnSpecificReview() throws Exception {
+                String id = createdMusicReview.getId().toString();
+                mockMvc.perform(get("/music-reviews/" + id).accept(MediaType.APPLICATION_JSON))
+                    .andExpect(
+                        status().is(200))
+                    .andExpect(
+                        content().string(containsString(reviewTitle)))
+                    .andExpect(
+                        content().string(containsString(musicLink)))
+                    .andExpect(
+                        content().string(containsString(description)));
+            }
+        }
+    }
 
     @Nested
     @DisplayName("음악 리뷰를 작성할 때")


### PR DESCRIPTION
기존에는 리뷰를 가져오기 위하여 모든 리뷰를 가져오는 방법밖에 없었습니다.
그러나 리뷰 하나만 가져오는 방법도 필요합니다.
따라서 음악 하나만 가져올 수 있도록 HTTP API를 만들었습니다.
이 API들은 react프로젝트인 `weather`에서 사용될 예정입니다.