### PR TITLE
음악 추천 상자 생성 HTTP API 구현

### DIFF
--- a/app/src/main/java/atmosphere/adapter/InMemoryMusicRecommendationBoxRepository.java
+++ b/app/src/main/java/atmosphere/adapter/InMemoryMusicRecommendationBoxRepository.java
@@ -2,11 +2,13 @@ package atmosphere.adapter;
 
 import atmosphere.domain.MusicRecommendationBox;
 import atmosphere.domain.MusicRecommendationBoxRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Repository
 public class InMemoryMusicRecommendationBoxRepository implements MusicRecommendationBoxRepository {
     private final Map<String, MusicRecommendationBox> cache;
 
@@ -22,5 +24,10 @@ public class InMemoryMusicRecommendationBoxRepository implements MusicRecommenda
     @Override
     public void save(MusicRecommendationBox model) {
         cache.put(model.id(), model);
+    }
+
+    @Override
+    public void deleteAll() {
+        cache.clear();
     }
 }

--- a/app/src/main/java/atmosphere/application/MusicRecommendApplicationService.java
+++ b/app/src/main/java/atmosphere/application/MusicRecommendApplicationService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 /**
  * 음악 추천에 관련된 유즈케이스를 담당합니다.
  */
+@Service
 public class MusicRecommendApplicationService {
     private final MusicRecommendationBoxRepository repository;
 
@@ -35,5 +36,12 @@ public class MusicRecommendApplicationService {
      */
     public Optional<MusicRecommendationBox> findMyMusicRecommendationBox(String userId) {
         return repository.findById(userId);
+    }
+
+    /**
+     * 서비스를 초기화합니다.
+     */
+    public void initialize() {
+        repository.deleteAll();
     }
 }

--- a/app/src/main/java/atmosphere/domain/MusicRecommendationBoxRepository.java
+++ b/app/src/main/java/atmosphere/domain/MusicRecommendationBoxRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 public interface MusicRecommendationBoxRepository {
     Optional<MusicRecommendationBox> findById(String id);
     void save(MusicRecommendationBox model);
+    void deleteAll();
 }

--- a/app/src/main/java/atmosphere/web/spring/controller/ControllerErrorAdvice.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/ControllerErrorAdvice.java
@@ -1,5 +1,6 @@
 package atmosphere.web.spring.controller;
 
+import atmosphere.error.AlreadyExistRecommendationBox;
 import atmosphere.error.NotFountMusicReview;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -7,10 +8,16 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class MusicReviewAdvice {
+public class ControllerErrorAdvice {
     @ExceptionHandler
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String errorHandler(NotFountMusicReview e) {
+        return e.getMessage();
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String errorHandler(AlreadyExistRecommendationBox e) {
         return e.getMessage();
     }
 }

--- a/app/src/main/java/atmosphere/web/spring/controller/MusicRecommendationBoxController.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/MusicRecommendationBoxController.java
@@ -1,0 +1,28 @@
+package atmosphere.web.spring.controller;
+
+import atmosphere.application.MusicRecommendApplicationService;
+import atmosphere.domain.MusicRecommendationBox;
+import atmosphere.web.spring.dto.MusicRecommendationBoxCreateDTO;
+import atmosphere.web.spring.dto.MusicRecommendationBoxDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@CrossOrigin(origins = "https://atmop.dev")
+@RequestMapping(path = "/music-recommendation-box", produces = "application/json;charset=UTF-8")
+public class MusicRecommendationBoxController {
+    private final MusicRecommendApplicationService service;
+
+    public MusicRecommendationBoxController(MusicRecommendApplicationService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MusicRecommendationBoxDTO createMusicRecommendationBox(
+        @RequestBody MusicRecommendationBoxCreateDTO createDTO
+    ) {
+        MusicRecommendationBox musicBox = service.createMusicRecommendationBox(createDTO.userId);
+        return MusicRecommendationBoxDTO.fromModel(musicBox);
+    }
+}

--- a/app/src/main/java/atmosphere/web/spring/dto/MusicRecommendationBoxCreateDTO.java
+++ b/app/src/main/java/atmosphere/web/spring/dto/MusicRecommendationBoxCreateDTO.java
@@ -1,0 +1,13 @@
+package atmosphere.web.spring.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MusicRecommendationBoxCreateDTO {
+    public String userId;
+
+    public MusicRecommendationBoxCreateDTO(
+        @JsonProperty("userId") String userId
+    ) {
+        this.userId = userId;
+    }
+}

--- a/app/src/main/java/atmosphere/web/spring/dto/MusicRecommendationBoxDTO.java
+++ b/app/src/main/java/atmosphere/web/spring/dto/MusicRecommendationBoxDTO.java
@@ -1,0 +1,16 @@
+package atmosphere.web.spring.dto;
+
+import atmosphere.domain.MusicRecommendationBox;
+
+public class MusicRecommendationBoxDTO {
+    public String id;
+
+    public MusicRecommendationBoxDTO(String id) {
+        this.id = id;
+    }
+
+    public static MusicRecommendationBoxDTO fromModel(MusicRecommendationBox model) {
+        return new MusicRecommendationBoxDTO(model.id());
+    }
+}
+

--- a/app/src/test/java/atmosphere/web/MusicRecommendationTest.java
+++ b/app/src/test/java/atmosphere/web/MusicRecommendationTest.java
@@ -1,0 +1,88 @@
+package atmosphere.web;
+
+import atmosphere.application.MusicRecommendApplicationService;
+import atmosphere.web.spring.dto.MusicRecommendationBoxCreateDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Nested
+public class MusicRecommendationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MusicRecommendApplicationService service;
+
+    @BeforeEach
+    void clearService() {
+        service.initialize();
+    }
+
+    @Nested
+    @DisplayName("음악 추천 상자를 생성할 때")
+    class Describe_createMusicRecommendationBox {
+        private final String userName = "LasWonho";
+
+        @Nested
+        @DisplayName("생성된 추천 상자가 없다면")
+        class Context_notExistMusicRecommendationBox {
+            @Test
+            @DisplayName("음악 추천 상자가 생성된다.")
+            void it_shouldCreateMusicRecommendationBox() throws Exception {
+                MusicRecommendationBoxCreateDTO data = new MusicRecommendationBoxCreateDTO(userName);
+                String requestBody = mapper.writeValueAsString(data);
+
+                mockMvc.perform(
+                    post("/music-recommendation-box")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(
+                        content().string(containsString(userName)))
+                    .andExpect(
+                        status().is(201));
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 추천 상자가 생성되었다면")
+        class Context_alreadyExistMusicRecommendationBox {
+            @BeforeEach
+            void createReview() {
+                service.createMusicRecommendationBox(userName);
+            }
+
+            @Test
+            @DisplayName("요청이 실패한다.")
+            void it_shouldFail() throws Exception {
+                MusicRecommendationBoxCreateDTO data = new MusicRecommendationBoxCreateDTO(userName);
+                String requestBody = mapper.writeValueAsString(data);
+
+                mockMvc.perform(
+                    post("/music-recommendation-box")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(
+                        status().is(400));
+            }
+        }
+    }
+}


### PR DESCRIPTION
기존에는 음악 추천 상자 생성 기능을 외부에서 이용하는게 불가능했습니다.
하지만, 우리는 웹 서비스로 이러한 기능을 제공해야 하고, react 프로젝트인 weather가 그것을 담당합니다.
따라서 HTTP API로 음악 추천 상자를 생성할 수 있도록 하였습니다.