### PR TITLE
음악 추천하기 API 구현

### DIFF
--- a/app/src/main/java/atmosphere/web/spring/controller/MusicRecommendationBoxController.java
+++ b/app/src/main/java/atmosphere/web/spring/controller/MusicRecommendationBoxController.java
@@ -3,6 +3,7 @@ package atmosphere.web.spring.controller;
 import atmosphere.application.MusicRecommendApplicationService;
 import atmosphere.domain.MusicRecommendationBox;
 import atmosphere.error.NotFountMusicRecommendationBox;
+import atmosphere.web.spring.dto.MusicDTO;
 import atmosphere.web.spring.dto.MusicRecommendationBoxCreateDTO;
 import atmosphere.web.spring.dto.MusicRecommendationBoxDTO;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,25 @@ public class MusicRecommendationBoxController {
         @PathVariable String id
     ) {
         Optional<MusicRecommendationBox> musicBox = service.findMyMusicRecommendationBox(id);
+        return musicBox.map(
+            MusicRecommendationBoxDTO::fromModel
+        ).orElseThrow(
+            () -> new NotFountMusicRecommendationBox(id)
+        );
+    }
+
+    @PostMapping("{id}/recommend")
+    @ResponseStatus(HttpStatus.CREATED)
+    public MusicRecommendationBoxDTO recommendMusic(
+        @PathVariable String id,
+        @RequestBody MusicDTO music
+    ) {
+        Optional<MusicRecommendationBox> musicBox = service.recommendMusic(
+            id,
+            music.musicLink,
+            music.title,
+            music.description
+        );
         return musicBox.map(
             MusicRecommendationBoxDTO::fromModel
         ).orElseThrow(


### PR DESCRIPTION
기존에는 음악을 추천하는 기능을 사용자가 외부에서 사용할 수 없었습니다.
하지만, 이 서비스는 웹서비스이기에 HTTP API를 공개하여야 합니다.
따라서 Spring을 이용하여 HTTP API를 구현하였습니다.